### PR TITLE
Separate CircleCI step for ScalaFmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ workflows:
   version: 2
   testDevelopmentBranch:
     jobs:
+      - scalaFmt:
+          filters:
+            tags:
+              ignore: /.*/
       - test:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 references:
   dependencies_key: &dependencies_key
-    sbt-v1-deps-{{ checksum "project/build.properties" }}-{{ checksum "project/plugins.sbt" }}-{{ checksum "build.sbt" }}
+                      sbt-v1-deps-{{ checksum "project/build.properties" }}-{{ checksum "project/plugins.sbt" }}-{{ checksum "build.sbt" }}
 
   restore_dependencies: &restore_dependencies
     restore_cache:
@@ -10,9 +10,26 @@ references:
         - *dependencies_key
 
   sbt_image: &sbt_image
-    moia/scala-on-circleci:8u232-2.12.10-sbt-1.3.8
+               moia/scala-on-circleci:8u232-2.12.10-sbt-1.3.8
 
 jobs:
+  scalaFmt:
+    docker:
+      - image: *sbt_image
+    steps:
+      - checkout
+      - *restore_dependencies
+      - run:
+          name: Check formatting
+          command: sbt -batch scalafmtCheckAll
+      - save_cache:
+          key: *dependencies_key
+          paths:
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.cache/coursier/
+
   test:
     docker:
       - image: *sbt_image
@@ -20,9 +37,9 @@ jobs:
       - checkout
       - *restore_dependencies
       - run:
-         name: Compile and Test
-         command: |
-           sbt -batch "; docs/mdoc; scalafmtCheckAll; +test; +doc; version"
+          name: Compile and Test
+          command: |
+            sbt -batch "; docs/mdoc; +test; +doc; version"
       - save_cache:
           key: *dependencies_key
           paths:


### PR DESCRIPTION
As #42 shows, formatting errors are shown as test errors which is irritating.
This creates a separate step in CircleCI to check the formatting of files using ScalaFmt.