### PR TITLE
add labeler rules file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,27 @@
+
+enable:
+  issues: false
+  prs: true
+# comments object allows you to specify a different message for issues and prs
+
+comments:
+  issues: |
+    Thanks for opening this issue!
+    I have applied any labels matching special text in your title and description.
+    Please review the labels and make any necessary changes.
+  prs: |
+    Thanks for the contribution!
+    I have applied any labels matching special text in your title and description.
+    Please review the labels and make any necessary changes.
+# Labels is an object where:
+# - keys are labels
+# - values are objects of { include: [ pattern ], exclude: [ pattern ] }
+#    - pattern must be a valid regex, and is applied globally to
+#      title + description of issues and/or prs (see enabled config above)
+#    - 'include' patterns will associate a label if any of these patterns match
+#    - 'exclude' patterns will ignore this label if any of these patterns match
+labels:
+  'automerge':
+    include:
+      - '\blabels:\s(\w\-*)+\-(update)\b'
+    exclude: []


### PR DESCRIPTION
So the reason why https://github.com/moia-dev/scynamo/pull/63 is failing, is because _auto-label_ looks for the **labeler.yml** in the **master** branch, as spotted by @nihalgonsalves . So it was never finding it in the feature branch. 

Here basically:
- we enable the autolabel only on PRs
- we define a rule, so that everything that constains something like 
```
  - labels: sbt-plugin-update
  - labels: library-update
  - labels: test-library-update
  - labels: *******-update 
```
would be labeled as `"automerge"`.

That PR needs to be merged first in order to auto-label to work.  
🤞 🤞 

Signed-off-by: cristina <cristina.heredia@moia.io>