### PR TITLE
Proposal: use pull_request_target in community.yml

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -2,7 +2,7 @@ name: Community
 on:
   issues:
     types: [opened, edited, milestoned]
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:


### PR DESCRIPTION
GitHub added support for pull_request_target after I released labeler-action.

The new event's context is the default branch rather than the PR branch. This allows access to the GitHub token, and labeling PRs from forks.

See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target