### PR TITLE
Special-case encoder for Option of empty string

### DIFF
--- a/src/main/scala/scynamo/ScynamoEncoder.scala
+++ b/src/main/scala/scynamo/ScynamoEncoder.scala
@@ -26,19 +26,18 @@ object ScynamoEncoder extends DefaultScynamoEncoderInstances {
 }
 
 trait DefaultScynamoEncoderInstances extends ScynamoIterableEncoder {
-  implicit val stringEncoder: ScynamoEncoder[String] = value => {
-    if (value.nonEmpty)
-      Right(AttributeValue.builder().s(value).build())
-    else
-      Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.String))
+  implicit val stringEncoder: ScynamoEncoder[String] = value =>
+    if (value.nonEmpty) Right(AttributeValue.builder().s(value).build())
+    else Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.String))
+
+  implicit val stringOptionEncoder: ScynamoEncoder[Option[String]] = {
+    case Some("") | None => Right(AttributeValue.builder().nul(true).build())
+    case Some(value)     => stringEncoder.encode(value)
   }
 
-  private[this] val numberStringEncoder: ScynamoEncoder[String] = value => {
-    if (value.nonEmpty)
-      Right(AttributeValue.builder().n(value).build())
-    else
-      Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.String))
-  }
+  private[this] val numberStringEncoder: ScynamoEncoder[String] = value =>
+    if (value.nonEmpty) Right(AttributeValue.builder().n(value).build())
+    else Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.String))
 
   implicit val intEncoder: ScynamoEncoder[Int] = numberStringEncoder.contramap[Int](_.toString)
 

--- a/src/test/scala/scynamo/ScynamoEncoderTest.scala
+++ b/src/test/scala/scynamo/ScynamoEncoderTest.scala
@@ -96,6 +96,10 @@ class ScynamoEncoderTest extends UnitTest {
       ScynamoEncoder[String].encode("") should ===(Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.String)))
     }
 
+    "support option of empty string" in {
+      ScynamoEncoder[Option[String]].encode(Some("")).exists(_.nul()) shouldBe true
+    }
+
     "fail on empty string set" in {
       ScynamoEncoder[ScynamoStringSet].encode(ScynamoStringSet(Set())) should ===(
         Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.StringSet))


### PR DESCRIPTION
This is a bit controversial because it breaks parametricity.
However after using the library for some time, I think in most
cases this is what users actually mean when using `Option[String]`
is actually `Option[NonEmptyString]` which doesn't exist in the
standard library.