### PR TITLE
MOIA-31842: Allow empty Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ and is very similar to other libraries in the Scala ecosystem.
 - customize the derivation of case classes and sealed traits using options
 - `AttributeValue`-Syntax for null-safe accessors
 - provides optional syntax for encoding/decoding (see `scynamo.syntax.*`)
-- *safe*: Instead of silently encoding empty `String`s and
-  {String,Number,Binary} Sets, this operation *fails* in `scynamo`,
+- *safe*: Instead of silently encoding empty {String,Number,Binary} Sets, this operation *fails* in `scynamo`,
   allowing you to catch the error before even reaching DynamoDB.  See
   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,8 +128,7 @@ new instances.
 
 ##### `contramap`/`map`/`imap`
 
-As an example you can modify the standard `String` encoder.decoder to *not*
-fail with empty strings:
+As an example you can modify the standard `String` encoder.decoder to replace an empty `String`:
 
 ```scala mdoc
 import scynamo._

--- a/src/main/scala/scynamo/ScynamoEncoder.scala
+++ b/src/main/scala/scynamo/ScynamoEncoder.scala
@@ -28,11 +28,6 @@ object ScynamoEncoder extends DefaultScynamoEncoderInstances {
 trait DefaultScynamoEncoderInstances extends ScynamoIterableEncoder {
   implicit val stringEncoder: ScynamoEncoder[String] = value => Right(AttributeValue.builder().s(value).build())
 
-  implicit val stringOptionEncoder: ScynamoEncoder[Option[String]] = {
-    case Some("") | None => Right(AttributeValue.builder().nul(true).build())
-    case Some(value)     => stringEncoder.encode(value)
-  }
-
   private[this] val numberStringEncoder: ScynamoEncoder[String] = value => Right(AttributeValue.builder().n(value).build())
 
   implicit val intEncoder: ScynamoEncoder[Int] = numberStringEncoder.contramap[Int](_.toString)

--- a/src/test/scala/scynamo/DslTest.scala
+++ b/src/test/scala/scynamo/DslTest.scala
@@ -1,5 +1,6 @@
 package scynamo
 
+import scynamo.wrapper.ScynamoStringSet
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 class DslTest extends UnitTest {
@@ -33,7 +34,7 @@ class DslTest extends UnitTest {
     "throw an exception with unsafe encoding" in {
       import scynamo.syntax.encoder._
 
-      val input = List("foo", "", "bar")
+      val input = ScynamoStringSet(Set())
 
       an[IllegalArgumentException] should be thrownBy {
         input.encodedUnsafe

--- a/src/test/scala/scynamo/ScynamoCodecProps.scala
+++ b/src/test/scala/scynamo/ScynamoCodecProps.scala
@@ -19,7 +19,7 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
   private[this] val bigDecimalGen: Gen[BigDecimal] = for {
     prefix <- Gen.nonEmptyListOf(Gen.numChar).map(_.mkString)
     suffix <- Gen.nonEmptyListOf(Gen.numChar).map(_.mkString)
-  } yield BigDecimal(s"${prefix}.${suffix}")
+  } yield BigDecimal(s"$prefix.$suffix")
 
   propertyWithSeed("decode.encode === id (int)", propertySeed) = Prop.forAll { value: Int => decodeAfterEncodeIsIdentity(value) }
 
@@ -37,6 +37,8 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
 
   propertyWithSeed("decode.encode === id (nonempty string)", propertySeed) =
     Prop.forAll(Gen.nonEmptyListOf(Gen.alphaNumChar).map(_.mkString)) { value: String => decodeAfterEncodeIsIdentity(value) }
+
+  property("decode.encode === id (empty string)") = decodeAfterEncodeIsIdentity("")
 
   propertyWithSeed("decode.encode === id (boolean)", propertySeed) = Prop.forAll { value: Boolean => decodeAfterEncodeIsIdentity(value) }
 

--- a/src/test/scala/scynamo/ScynamoEncoderTest.scala
+++ b/src/test/scala/scynamo/ScynamoEncoderTest.scala
@@ -91,10 +91,6 @@ class ScynamoEncoderTest extends UnitTest {
       }
     }
 
-    "support option of empty string" in {
-      ScynamoEncoder[Option[String]].encode(Some("")).exists(_.nul()) shouldBe true
-    }
-
     "fail on empty string set" in {
       ScynamoEncoder[ScynamoStringSet].encode(ScynamoStringSet(Set())) should ===(
         Either.leftNec(ScynamoEncodeError.invalidEmptyValue(ScynamoType.StringSet))


### PR DESCRIPTION
_DynamoDB_ does support empty `String`s now:
https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/?nc1=h_ls
(Except for keys.)

This allows empty `String`s and updates the tests and documentation.